### PR TITLE
Disable telemetry by default

### DIFF
--- a/download-caddy.go
+++ b/download-caddy.go
@@ -116,7 +116,7 @@ func main() {
 		}
 		filepath := path.Join(wd, filename)
 
-		queryString := fmt.Sprintf("license=personal&plugins=%s", featureList)
+		queryString := fmt.Sprintf("license=personal&telemetry=off&plugins=%s", featureList)
 		rawURL := fmt.Sprintf("%s/%s?%s", rootURL, arch, queryString)
 		u, err := url.Parse(rawURL)
 		if err != nil {


### PR DESCRIPTION
Caddy includes opt-out telemetry since version 0.11.0, this patch opts out